### PR TITLE
Add placeholder viral MSAs and training scripts

### DIFF
--- a/data/MSA/fusion_core_T30_aligned.stats
+++ b/data/MSA/fusion_core_T30_aligned.stats
@@ -1,0 +1,2 @@
+length: 10
+sequences: 2

--- a/data/MSA/fusion_core_T30_aligned_EVEprep.a2m
+++ b/data/MSA/fusion_core_T30_aligned_EVEprep.a2m
@@ -1,0 +1,4 @@
+>reference
+ABCDEFGHIK
+>seq1
+AB-DEFGHIK

--- a/data/MSA/hsv1_gb_FLs_T30_aligned.stats
+++ b/data/MSA/hsv1_gb_FLs_T30_aligned.stats
@@ -1,0 +1,2 @@
+length: 10
+sequences: 2

--- a/data/MSA/hsv1_gb_FLs_T30_ref.a2m
+++ b/data/MSA/hsv1_gb_FLs_T30_ref.a2m
@@ -1,0 +1,4 @@
+>reference
+QRSTVWYACD
+>seq1
+QRSTVWYAC-

--- a/data/MSA/hsv1_gb_FLs_T30_ref_EVEprep.a2m
+++ b/data/MSA/hsv1_gb_FLs_T30_ref_EVEprep.a2m
@@ -1,0 +1,4 @@
+>reference
+QRSTVWYACD
+>seq1
+QRSTVWYACD

--- a/data/MSA/rsvF_HR1_T23_aligned.stats
+++ b/data/MSA/rsvF_HR1_T23_aligned.stats
@@ -1,0 +1,2 @@
+length: 10
+sequences: 3

--- a/data/MSA/rsvF_HR1_T23_ref.a2m
+++ b/data/MSA/rsvF_HR1_T23_ref.a2m
@@ -1,0 +1,6 @@
+>reference
+ACDEFGHIKL
+>seq1
+ACDEFGHIK-
+>seq2
+ACDEFGHIKL

--- a/data/MSA/rsvF_HR1_T23_ref_EVEprep.a2m
+++ b/data/MSA/rsvF_HR1_T23_ref_EVEprep.a2m
@@ -1,0 +1,4 @@
+>reference
+ACDEFGHIKL
+>seq1
+AC-EFGHIKL

--- a/data/MSA/rsvF_HR2_T17_aligned.stats
+++ b/data/MSA/rsvF_HR2_T17_aligned.stats
@@ -1,0 +1,2 @@
+length: 10
+sequences: 3

--- a/data/MSA/rsvF_HR2_T17_ref.a2m
+++ b/data/MSA/rsvF_HR2_T17_ref.a2m
@@ -1,0 +1,6 @@
+>reference
+MNPQRSTVWY
+>seq1
+MNPRRSTVWY
+>seq2
+MNPQRSTVW-

--- a/data/MSA/rsvF_HR2_T17_ref_EVEprep.a2m
+++ b/data/MSA/rsvF_HR2_T17_ref_EVEprep.a2m
@@ -1,0 +1,4 @@
+>reference
+MNPQRSTVWY
+>seq1
+MNPQRSTVWY

--- a/data/mappings/custom_mapping.csv
+++ b/data/mappings/custom_mapping.csv
@@ -1,0 +1,5 @@
+protein_name,msa_location,theta
+rsvF_HR1_T23,rsvF_HR1_T23_ref_EVEprep.a2m,0.2
+rsvF_HR2_T17,rsvF_HR2_T17_ref_EVEprep.a2m,0.2
+fusion_core_T30,fusion_core_T30_aligned_EVEprep.a2m,0.2
+hsv1_gb_FLs_T30,hsv1_gb_FLs_T30_ref_EVEprep.a2m,0.2

--- a/examples/Step1_train_VAE_custom.sh
+++ b/examples/Step1_train_VAE_custom.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+export MSA_data_folder='./data/MSA'
+export MSA_list='./data/mappings/custom_mapping.csv'
+export MSA_weights_location='./data/weights'
+export VAE_checkpoint_location='./results/VAE_parameters'
+export model_name_suffix='Jan1_custom_example'
+export model_parameters_location='./EVE/default_model_params.json'
+export training_logs_location='./logs/'
+
+for protein_index in 0 1 2 3; do
+python train_VAE.py \
+    --MSA_data_folder ${MSA_data_folder} \
+    --MSA_list ${MSA_list} \
+    --protein_index ${protein_index} \
+    --MSA_weights_location ${MSA_weights_location} \
+    --VAE_checkpoint_location ${VAE_checkpoint_location} \
+    --model_name_suffix ${model_name_suffix} \
+    --model_parameters_location ${model_parameters_location} \
+    --training_logs_location ${training_logs_location}
+
+done

--- a/examples/Step2_compute_evol_indices_all_singles_custom.sh
+++ b/examples/Step2_compute_evol_indices_all_singles_custom.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+export MSA_data_folder='./data/MSA'
+export MSA_list='./data/mappings/custom_mapping.csv'
+export MSA_weights_location='./data/weights'
+export VAE_checkpoint_location='./results/VAE_parameters'
+export model_name_suffix='Jan1_custom_example'
+export model_parameters_location='./EVE/default_model_params.json'
+export training_logs_location='./logs/'
+
+export computation_mode='all_singles'
+export all_singles_mutations_folder='./data/mutations'
+export output_evol_indices_location='./results/evol_indices'
+export num_samples_compute_evol_indices=20000
+export batch_size=2048
+
+for protein_index in 0 1 2 3; do
+python compute_evol_indices.py \
+    --MSA_data_folder ${MSA_data_folder} \
+    --MSA_list ${MSA_list} \
+    --protein_index ${protein_index} \
+    --MSA_weights_location ${MSA_weights_location} \
+    --VAE_checkpoint_location ${VAE_checkpoint_location} \
+    --model_name_suffix ${model_name_suffix} \
+    --model_parameters_location ${model_parameters_location} \
+    --computation_mode ${computation_mode} \
+    --all_singles_mutations_folder ${all_singles_mutations_folder} \
+    --output_evol_indices_location ${output_evol_indices_location} \
+    --num_samples_compute_evol_indices ${num_samples_compute_evol_indices} \
+    --batch_size ${batch_size}
+done

--- a/examples/Step3_train_GMM_and_compute_EVE_scores_all_singles_custom.sh
+++ b/examples/Step3_train_GMM_and_compute_EVE_scores_all_singles_custom.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+export input_evol_indices_location='./results/evol_indices'
+export input_evol_indices_filename_suffix='_20000_samples'
+export protein_list='./data/mappings/custom_mapping.csv'
+export output_eve_scores_location='./results/EVE_scores'
+export output_eve_scores_filename_suffix='Jan1_custom_example'
+
+export GMM_parameter_location='./results/GMM_parameters/Default_GMM_parameters'
+export GMM_parameter_filename_suffix='default'
+export protein_GMM_weight=0.3
+export plot_location='./results'
+export default_uncertainty_threshold_file_location='./utils/default_uncertainty_threshold.json'
+
+python train_GMM_and_compute_EVE_scores.py \
+    --input_evol_indices_location ${input_evol_indices_location} \
+    --input_evol_indices_filename_suffix ${input_evol_indices_filename_suffix} \
+    --protein_list ${protein_list} \
+    --output_eve_scores_location ${output_eve_scores_location} \
+    --output_eve_scores_filename_suffix ${output_eve_scores_filename_suffix} \
+    --load_GMM_models \
+    --GMM_parameter_location ${GMM_parameter_location} \
+    --GMM_parameter_filename_suffix ${GMM_parameter_filename_suffix} \
+    --compute_EVE_scores \
+    --protein_GMM_weight ${protein_GMM_weight} \
+    --plot_histograms \
+    --plot_location ${plot_location} \
+    --default_uncertainty_threshold_file_location ${default_uncertainty_threshold_file_location} \
+    --verbose
+


### PR DESCRIPTION
## Summary
- add example RSV fusion, RSV HR2, fusion core and HSV1 glycoprotein B MSAs and stats
- provide mapping file for new MSAs
- include example scripts for training, computing evol indices and EVE scores for the new alignments

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ab10e5d4a4832082b2f8a46ba33480